### PR TITLE
Pull out the website field from HackerOne to further improve data.

### DIFF
--- a/lib/bounty-targets/hackerone.rb
+++ b/lib/bounty-targets/hackerone.rb
@@ -55,7 +55,8 @@ module BountyTargets
               offers_swag: node.offers_swag || false,
               response_efficiency_percentage: node.response_efficiency_percentage,
               submission_state: node.submission_state,
-              url: node.url
+              url: node.url,
+              website: node.website
             }
           end)
         end
@@ -145,7 +146,8 @@ module BountyTargets
               response_efficiency_percentage,
               submission_state,
               triage_active,
-              url
+              url,
+              website
             }
           }
         }


### PR DESCRIPTION
Many programs (i.e. https://hackerone.com/keybase) do not contain any structured scope information. This makes getting started with a program difficult, as you have to realize you have no scope data for a program, and then manually visit the page, collect valid scope yourself, etc.

The `website` field on HackerOne is a good starting point that is useful to pull in (with human review). For the above program, taking the root domain of their `website` field would yield an accurate scope. Of course, if you pulled in https://hackerone.com/msdos, it wouldn't -- so it's not foolproof! However, I think this is a valuable addition to the data.

BTW, thanks for fixing the Bugcrowd scope. This one was easier to write with little Ruby knowledge. :)